### PR TITLE
remove superclass for metadataDialogs

### DIFF
--- a/modules/gui/src/de/diedavids/cuba/metadataextensions/MetadataDialogs.java
+++ b/modules/gui/src/de/diedavids/cuba/metadataextensions/MetadataDialogs.java
@@ -8,7 +8,7 @@ import com.haulmont.cuba.gui.screen.FrameOwner;
 
 
 
-public interface MetadataDialogs extends Dialogs {
+public interface MetadataDialogs {
 
 
     String NAME = "ddcme_MetadataDialogs";

--- a/modules/web/src/de/diedavids/cuba/metadataextensions/web/MetadataDialogsImpl.java
+++ b/modules/web/src/de/diedavids/cuba/metadataextensions/web/MetadataDialogsImpl.java
@@ -19,11 +19,7 @@ import static com.haulmont.cuba.gui.app.core.inputdialog.InputDialog.INPUT_DIALO
 
 
 @Component(MetadataDialogs.NAME)
-public class MetadataDialogsImpl extends WebDialogs implements MetadataDialogs {
-
-    public MetadataDialogsImpl(AppUI ui) {
-        super(ui);
-    }
+public class MetadataDialogsImpl implements MetadataDialogs {
 
     @Override
     public MetadataInputDialogBuilder createMetadataInputDialog(FrameOwner owner) {


### PR DESCRIPTION
alternative approach:

remove the superclass. There is unfortunately a compile error for the builder:

<img width="2032" alt="Bildschirmfoto 2019-10-29 um 13 30 20" src="https://user-images.githubusercontent.com/817400/67767198-688e6180-fa50-11e9-90de-375c8fcf197d.png">
